### PR TITLE
add ENV to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ COPY docker/proxy.conf /etc/nginx/conf.d/proxy.conf
 COPY docker/default.conf.template /etc/nginx/templates/default.conf.template
 COPY docker/proxy_params.conf /etc/nginx/snippets/proxy_params.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
+ENV API_HOST=typhon-polystore-service
+ENV API_PORT=8080


### PR DESCRIPTION
Closes #4 
Adds the default environment to the image. If a different environment is needed for development or testing purposes, it can be added to the deployment script with
```
    environment:
      API_PORT: "8080"
      API_HOST: "localhost"
```
for docker compose and
```
          env:
            - name: API_PORT
              value: "8080"
            - name: API_HOST
              value: "localhost"
```
for kubernetes.